### PR TITLE
Update to @std/esm 0.10.0+ for import.meta.url support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Asaf Katz",
   "license": "MIT",
   "dependencies": {
-    "@std/esm": "^0.9.2",
+    "@std/esm": "^0.10.2",
     "chokidar": "^1.7.0",
     "electron": "~1.6.2",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Hi @asfktz!

This project looks pretty cool. I was curious about `@std/esm`'s support in Electron.
I've updated @std/esm to 0.10.0+ for `import.meta.url` support.